### PR TITLE
typo fix

### DIFF
--- a/ttl/srophe/places/syriaca-org-place-10.ttl
+++ b/ttl/srophe/places/syriaca-org-place-10.ttl
@@ -5,7 +5,7 @@
 @prefix lawd: <http://lawd.info/ontology/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#>.
 @prefix periodo: <http://n2t.net/ark:/99152/p0v#>.
-@prefix person: <https://www.w3.org/ns/person>,
+@prefix person: <https://www.w3.org/ns/person>.
 @prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
 @prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
 @prefix schema: <http://schema.org/> .


### PR DESCRIPTION
Typo fix: comma misuse instead of a dot